### PR TITLE
bytefail: Stop compiler from reordering

### DIFF
--- a/bytefail/src/elink-test1-device.c
+++ b/bytefail/src/elink-test1-device.c
@@ -51,117 +51,114 @@ typedef struct {
         uint32_t flag;
 } test_t;
 
-#define loop()  for(n=0; n<1000; n++) {}
-
 int main(void)
 {
-	register test_t *monkey asm("r20") = (void *) 0x7000;
-	register uint32_t foo asm("r21") = 0x84838281;
+	register volatile test_t *monkey asm("r20") = (void *) 0x7000;
+	register volatile uint32_t foo asm("r21") = 0x84838281;
 	register volatile void *local asm("r22") = (void *) 0x6ff0;
 	register volatile void *chip  asm("r23") = (void *) 0x80901000;
 	register volatile void *eram  asm("r24") = (void *) 0x8f100000;
 	int  n;
 
-	*((uint32_t *)local) = 0xdeadbeef;
-	*((uint32_t *)chip) = 0xdeadbeef;
-	*((uint32_t *)eram) = 0xdeadbeef;
-	loop();
+	*((volatile uint32_t *)local) = 0xdeadbeef;
+	*((volatile uint32_t *)chip) = 0xdeadbeef;
+	*((volatile uint32_t *)eram) = 0xdeadbeef;
+	while (*((volatile uint32_t *)eram) == 0) ;
 
 	memset((void *) monkey, 0xAB, sizeof(*monkey));
 
 	/* Read test */
-	*((uint32_t *)local) = foo;
-	*((uint32_t *)chip) = foo;
-	*((uint32_t *)eram) = foo;
-	loop();
+	*((volatile uint32_t *)local) = foo;
+	*((volatile uint32_t *)chip) = foo;
+	*((volatile uint32_t *)eram) = foo;
+	while (*((volatile uint32_t *)eram) == 0) ;
 
-	monkey->local_read = *((uint8_t*) local);
-	monkey->chip_read = *((uint8_t*) chip);
-	monkey->eram_read =  *((uint8_t*) eram);
+	monkey->local_read = *((volatile uint8_t*) local);
+	monkey->chip_read  = *((volatile uint8_t*) chip);
+	monkey->eram_read  = *((volatile uint8_t*) eram);
 
-	monkey->local_sread = *((int8_t*) local);
-	monkey->chip_sread = *((int8_t*) chip);
-	monkey->eram_sread = *((int8_t*) eram);
+	monkey->local_sread = *((volatile int8_t*) local);
+	monkey->chip_sread  = *((volatile int8_t*) chip);
+	monkey->eram_sread  = *((volatile int8_t*) eram);
 
 	/* Write test */
 
 	/* Reset memory locations */
-	*((uint32_t *)local) = 0x0;
-	*((uint32_t *)chip) = 0x0;
-	*((uint32_t *)eram) = 0x0;
-	loop();
+	*((volatile uint32_t *)local) = 0x0;
+	*((volatile uint32_t *)chip) = 0x0;
+	*((volatile uint32_t *)eram) = 0x0;
+	while (*((volatile uint32_t *)eram) != 0) ;
 
-	*((uint8_t *)local) = foo;
-	*((uint8_t *)chip) = foo;
-	*((uint8_t *)eram) = foo;
-	loop();
+	*((volatile uint8_t *)local) = foo;
+	*((volatile uint8_t *)chip) = foo;
+	*((volatile uint8_t *)eram) = foo;
+	while (*((volatile uint32_t *)eram) == 0) ;
 
-	monkey->local_write = *((uint32_t*) local);
-	monkey->chip_write = *((uint32_t*) chip);
-	monkey->eram_write =  *((uint32_t*) eram);
+	monkey->local_write = *((volatile uint32_t*) local);
+	monkey->chip_write =  *((volatile uint32_t*) chip);
+	monkey->eram_write =  *((volatile uint32_t*) eram);
 
-	*((uint32_t *)local) = 0x0;
-	*((uint32_t *)chip) = 0x0;
-	*((uint32_t *)eram) = 0x0;
-	loop();
+	*((volatile uint32_t *)local) = 0x0;
+	*((volatile uint32_t *)chip) = 0x0;
+	*((volatile uint32_t *)eram) = 0x0;
+	while (*((volatile uint32_t *)eram) != 0) ;
 
-	*((int8_t *)local) = foo;  // Don't expect this to be different, but...
-	*((int8_t *)chip) = foo;
-	*((int8_t *)eram) = foo;
-	loop();
+	*((volatile int8_t *)local) = foo;  // Don't expect this to be different, but...
+	*((volatile int8_t *)chip) = foo;
+	*((volatile int8_t *)eram) = foo;
+	while (*((volatile uint32_t *)eram) == 0) ;
 
-	monkey->local_swrite = *((uint32_t*) local);
-	monkey->chip_swrite = *((uint32_t*) chip);
-	monkey->eram_swrite =  *((uint32_t*) eram);
+	monkey->local_swrite = *((volatile uint32_t*) local);
+	monkey->chip_swrite  = *((volatile uint32_t*) chip);
+	monkey->eram_swrite  = *((volatile uint32_t*) eram);
 
 	// Now repeat for 16b operations...
 #if 1
 	/* Read test */
-	*((uint32_t *)local) = foo;
-	*((uint32_t *)chip) = foo;
-	*((uint32_t *)eram) = foo;
-	loop();
+	*((volatile uint32_t *)local) = foo;
+	*((volatile uint32_t *)chip) = foo;
+	*((volatile uint32_t *)eram) = foo;
+	while (*((volatile uint32_t *)eram) == 0) ;
 
-	monkey->local_read_16 = *((uint16_t*) local);
-	monkey->chip_read_16 = *((uint16_t*) chip);
-	monkey->eram_read_16 =  *((uint16_t*) eram);
-	loop();
+	monkey->local_read_16 = *((volatile uint16_t*) local);
+	monkey->chip_read_16  = *((volatile uint16_t*) chip);
+	monkey->eram_read_16  = *((volatile uint16_t*) eram);
 
-	monkey->local_sread_16 = *((int16_t*) local);
-	monkey->chip_sread_16 = *((int16_t*) chip);
-	monkey->eram_sread_16 = *((int16_t*) eram);
+	monkey->local_sread_16 = *((volatile int16_t*) local);
+	monkey->chip_sread_16  = *((volatile int16_t*) chip);
+	monkey->eram_sread_16  = *((volatile int16_t*) eram);
 
 	/* Write test */
 
 	/* Reset memory locations */
-	*((uint32_t *)local) = 0x0;
-	*((uint32_t *)chip) = 0x0;
-	*((uint32_t *)eram) = 0x0;
-	loop();
+	*((volatile uint32_t *)local) = 0x0;
+	*((volatile uint32_t *)chip)  = 0x0;
+	*((volatile uint32_t *)eram)  = 0x0;
+	while (*((volatile uint32_t *)eram) != 0) ;
 
-	*((uint16_t *)local) = foo;
-	*((uint16_t *)chip) = foo;
-	*((uint16_t *)eram) = foo;
-	loop();
+	*((volatile uint16_t *)local) = foo;
+	*((volatile uint16_t *)chip) = foo;
+	*((volatile uint16_t *)eram) = foo;
+	while (*((volatile uint16_t *)eram) == 0) ;
 
-	monkey->local_write_16 = *((uint32_t*) local);
-	monkey->chip_write_16 = *((uint32_t*) chip);
-	monkey->eram_write_16 =  *((uint32_t*) eram);
-	loop();
+	monkey->local_write_16 = *((volatile uint32_t*) local);
+	monkey->chip_write_16  = *((volatile uint32_t*) chip);
+	monkey->eram_write_16  = *((volatile uint32_t*) eram);
 
-	*((uint32_t *)local) = 0x0;
-	*((uint32_t *)chip) = 0x0;
-	*((uint32_t *)eram) = 0x0;
-	loop();
+	*((volatile uint32_t *)local) = 0x0;
+	*((volatile uint32_t *)chip) = 0x0;
+	*((volatile uint32_t *)eram) = 0x0;
+	while (*((volatile uint32_t *)eram) != 0) ;
 
-	*((int16_t *)local) = foo;  // Don't expect this to be different, but...
-	*((int16_t *)chip) = foo;
-	*((int16_t *)eram) = foo;
-	loop();
 
-	monkey->local_swrite_16 = *((uint32_t*) local);
-	monkey->chip_swrite_16 = *((uint32_t*) chip);
-	monkey->eram_swrite_16 =  *((uint32_t*) eram);
+	*((volatile int16_t *)local) = foo;  // Don't expect this to be different, but...
+	*((volatile int16_t *)chip) = foo;
+	*((volatile int16_t *)eram) = foo;
+	while (*((volatile int16_t *)eram) == 0) ;
+
+	monkey->local_swrite_16 = *((volatile uint32_t*) local);
+	monkey->chip_swrite_16  = *((volatile uint32_t*) chip);
+	monkey->eram_swrite_16  = *((volatile uint32_t*) eram);
 #endif
 
 	monkey->flag = 0xCAFECAFE;


### PR DESCRIPTION
Stop compiler from reordering.
Use a read loop instead of a dummy loop.

Signed-off-by: Ola Jeppsson ola@adapteva.com
